### PR TITLE
Doc tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,16 +32,17 @@ jobs:
       with:
         # can be a link to a git repo or a local path
         template: https://github.com/cjolowicz/cookiecutter-hypermodern-python
-        cookiecutterValues: '{
-           "foo": "bar",
-           "baz": "boo",
-           "num": 2
-         }'
+        cookiecutterValues: |
+          {
+            "foo": "bar",
+            "baz": "boo",
+            "num": 2
+          }
 ```
 
 Or to use a cookiecutter in a private repo, use a checkout with a token that has access to that repo
 
-```
+```yaml
 name: Run Cookiecutter Private
 on: [workflow_dispatch]
 jobs:
@@ -57,11 +58,12 @@ jobs:
       with:
         # path to what you checked out
         template: ./yourprivatecookiecutter
-        cookiecutterValues: '{
-           "foo": "bar",
-           "baz": "boo",
-           "num": 2
-         }'
+        cookiecutterValues: |
+          {
+            "foo": "bar",
+            "baz": "boo",
+            "num": 2
+          }
 ```
 <!-- action-docs-inputs -->
 ## Inputs


### PR DESCRIPTION
* Set syntax-highlighting to `yaml` for the second block
* Correct syntax for multi-line strings - on my system, at least, the example given results in `Unexpected flow-map-end token in YAML stream`.